### PR TITLE
upgrade maven-bundle-plugin and revert workaround for java11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,7 @@
     <properties>
         <java.compliance>11</java.compliance>
         <maven-release-plugin.version>2.5.2</maven-release-plugin.version>
-        <!-- FIXME need to be updated when it will support java 11 -->
-        <maven-bundle-plugin.version>3.5.1</maven-bundle-plugin.version>
+        <maven-bundle-plugin.version>4.1.0</maven-bundle-plugin.version>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
         <jarjar-maven-plugin.version>1.9</jarjar-maven-plugin.version>

--- a/yar-api/pom.xml
+++ b/yar-api/pom.xml
@@ -61,8 +61,6 @@
                 <configuration>
                     <instructions>
                         <Import-Package>com.google.common.*;version=${guava.version},javax.annotation;resolution:=optional,*</Import-Package>
-                        <!-- FIXME need to be removed when maven-bundle-plugin supports java 11 -->
-                        <_noee>true</_noee>
                     </instructions>
                 </configuration>
             </plugin>

--- a/yar-guice-osgi/pom.xml
+++ b/yar-guice-osgi/pom.xml
@@ -68,8 +68,6 @@
                     <instructions>
                         <Bundle-Activator>org.javabits.yar.guice.osgi.internal.Activator</Bundle-Activator>
                         <Import-Package>com.google.common.*;version=${guava.version},javax.annotation;resolution:=optional,*</Import-Package>
-                        <!-- FIXME need to be removed when maven-bundle-plugin supports java 11 -->
-                        <_noee>true</_noee>
                     </instructions>
                 </configuration>
             </plugin>

--- a/yar-guice/pom.xml
+++ b/yar-guice/pom.xml
@@ -80,8 +80,6 @@
                 <configuration>
                     <instructions>
                         <Import-Package>com.google.common.*;version=${guava.version},javax.annotation;resolution:=optional,*</Import-Package>
-                        <!-- FIXME need to be removed when maven-bundle-plugin supports java 11 -->
-                        <_noee>true</_noee>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
To resolve FIXMEs on maven-bundle-plugin not knowing java11